### PR TITLE
[JITERA] Implement Production Repository and Service Layer

### DIFF
--- a/WebApplication1/Application/Services/ProductionService.cs
+++ b/WebApplication1/Application/Services/ProductionService.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using WebApplication1.Models;
+using WebApplication1.Domain.Repositories;
+
+namespace WebApplication1.Application.Services
+{
+    public class ProductionService
+    {
+        private readonly IProductionRepository _repository;
+
+        public ProductionService(IProductionRepository repository)
+        {
+            _repository = repository;
+        }
+
+        public Task<IEnumerable<Production>> GetAllAsync()
+        {
+            return _repository.GetAllAsync();
+        }
+
+        public Task<Production?> GetByIdAsync(Guid id)
+        {
+            return _repository.GetByIdAsync(id);
+        }
+
+        public Task AddAsync(Production production)
+        {
+            return _repository.AddAsync(production);
+        }
+
+        public Task UpdateAsync(Production production)
+        {
+            return _repository.UpdateAsync(production);
+        }
+
+        public Task DeleteAsync(Guid id)
+        {
+            return _repository.DeleteAsync(id);
+        }
+    }
+}

--- a/WebApplication1/Domain/Repositories/IProductionRepository.cs
+++ b/WebApplication1/Domain/Repositories/IProductionRepository.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using WebApplication1.Models;
+
+namespace WebApplication1.Domain.Repositories
+{
+    public interface IProductionRepository
+    {
+        Task<IEnumerable<Production>> GetAllAsync();
+        Task<Production?> GetByIdAsync(Guid id);
+        Task AddAsync(Production production);
+        Task UpdateAsync(Production production);
+        Task DeleteAsync(Guid id);
+    }
+}

--- a/WebApplication1/Infrastructure/Repositories/ProductionRepository.cs
+++ b/WebApplication1/Infrastructure/Repositories/ProductionRepository.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using WebApplication1.Models;
+using WebApplication1.Domain.Repositories;
+
+namespace WebApplication1.Infrastructure.Repositories
+{
+    public class ProductionRepository : IProductionRepository
+    {
+        private readonly ApplicationDbContext _context;
+
+        public ProductionRepository(ApplicationDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<IEnumerable<Production>> GetAllAsync()
+        {
+            return await _context.Productions.AsNoTracking().ToListAsync();
+        }
+
+        public async Task<Production?> GetByIdAsync(Guid id)
+        {
+            return await _context.Productions.FindAsync(id);
+        }
+
+        public async Task AddAsync(Production production)
+        {
+            await _context.Productions.AddAsync(production);
+            await _context.SaveChangesAsync();
+        }
+
+        public async Task UpdateAsync(Production production)
+        {
+            _context.Productions.Update(production);
+            await _context.SaveChangesAsync();
+        }
+
+        public async Task DeleteAsync(Guid id)
+        {
+            var entity = await _context.Productions.FindAsync(id);
+            if (entity != null)
+            {
+                _context.Productions.Remove(entity);
+                await _context.SaveChangesAsync();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Overview
This pull request introduces the implementation of the Production repository and service layer following the Domain-Driven Design (DDD) structure. It includes the creation of the repository interface, its implementation, and the service that interacts with the repository.

## Changes
1. **Production Repository Interface**
   - **File:** `/WebApplication1/Domain/Repositories/IProductionRepository.cs`
   - **Description:** Created an interface `IProductionRepository` that defines the contract for the repository, including methods for CRUD operations.

2. **Production Repository Implementation**
   - **File:** `/WebApplication1/Infrastructure/Repositories/ProductionRepository.cs`
   - **Description:** Implemented the `ProductionRepository` class that provides the actual logic for interacting with the database using Entity Framework. This includes methods to get all productions, get a production by ID, add, update, and delete productions.

3. **Production Service**
   - **File:** `/WebApplication1/Application/Services/ProductionService.cs`
   - **Description:** Created the `ProductionService` class that acts as an intermediary between the API controllers and the repository. It provides methods to access the repository's functionality, ensuring separation of concerns and adherence to the DDD principles.

This implementation sets the foundation for the next steps, which will involve creating the API controller for handling HTTP requests related to productions.
