### PR TITLE
[JITERA] Add ProjectController for CRUD operations

### DIFF
--- a/WebApplication1/Controllers/ProjectController.cs
+++ b/WebApplication1/Controllers/ProjectController.cs
@@ -1,0 +1,117 @@
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Threading.Tasks;
+using WebApplication1.Models;
+
+namespace WebApplication1.Controllers
+{
+    public class ProjectController : Controller
+    {
+        private readonly ApplicationDbContext _context;
+
+        public ProjectController(ApplicationDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<IActionResult> Index()
+        {
+            var projects = _context.Projects;
+            return View(await Task.FromResult(projects));
+        }
+
+        public async Task<IActionResult> Details(Guid id)
+        {
+            var project = await _context.Projects.FindAsync(id);
+            if (project == null)
+            {
+                return NotFound();
+            }
+            return View(project);
+        }
+
+        public IActionResult Create()
+        {
+            return View();
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Create([Bind("Name,Description")] Project project)
+        {
+            if (ModelState.IsValid)
+            {
+                project.ID = Guid.NewGuid();
+                _context.Add(project);
+                await _context.SaveChangesAsync();
+                return RedirectToAction(nameof(Index));
+            }
+            return View(project);
+        }
+
+        public async Task<IActionResult> Edit(Guid id)
+        {
+            var project = await _context.Projects.FindAsync(id);
+            if (project == null)
+            {
+                return NotFound();
+            }
+            return View(project);
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Edit(Guid id, [Bind("ID,Name,Description,RowVersion")] Project project)
+        {
+            if (id != project.ID)
+            {
+                return NotFound();
+            }
+
+            if (ModelState.IsValid)
+            {
+                try
+                {
+                    _context.Update(project);
+                    await _context.SaveChangesAsync();
+                }
+                catch (Exception)
+                {
+                    if (!_context.Projects.Any(e => e.ID == id))
+                    {
+                        return NotFound();
+                    }
+                    else
+                    {
+                        throw;
+                    }
+                }
+                return RedirectToAction(nameof(Index));
+            }
+            return View(project);
+        }
+
+        public async Task<IActionResult> Delete(Guid id)
+        {
+            var project = await _context.Projects.FindAsync(id);
+            if (project == null)
+            {
+                return NotFound();
+            }
+            return View(project);
+        }
+
+        [HttpPost, ActionName("Delete")]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> DeleteConfirmed(Guid id)
+        {
+            var project = await _context.Projects.FindAsync(id);
+            if (project != null)
+            {
+                _context.Projects.Remove(project);
+                await _context.SaveChangesAsync();
+            }
+            return RedirectToAction(nameof(Index));
+        }
+    }
+}


### PR DESCRIPTION
## Overview
This pull request introduces a new controller, `ProjectController`, to the project. The controller is responsible for handling CRUD operations related to projects, addressing the issue of the missing `ProjectController.cs` file in the project structure.

## Changes
- **New File**: Created `/WebApplication1/Controllers/ProjectController.cs`
- **Controller Implementation**: 
  - Added basic CRUD actions: `Index`, `Details`, `Create`, `Edit`, and `Delete`.
  - Implemented dependency injection for `ApplicationDbContext`.
  - Each action method is asynchronous and follows the standard practices for MVC controllers.

### Code Details
The `ProjectController` includes the following methods:
- **Index**: Retrieves and displays a list of projects.
- **Details**: Fetches and displays details of a specific project by ID.
- **Create**: Displays a form for creating a new project and handles the form submission.
- **Edit**: Displays a form for editing an existing project and handles the form submission.
- **Delete**: Displays a confirmation page for deleting a project and handles the deletion.

This implementation follows the conventions established in the existing `ProductionController` and adheres to the project's standards.

By adding this controller, we resolve the build errors related to the missing `ProjectController.cs` file and ensure that the project can handle project-related operations effectively.
